### PR TITLE
Limit the negative motion to -5.0mm

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1349,7 +1349,7 @@
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS 0
-#define Y_MIN_POS 0
+#define Y_MIN_POS -5.0
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE
@@ -1374,7 +1374,7 @@
 #define MIN_SOFTWARE_ENDSTOPS
 #if ENABLED(MIN_SOFTWARE_ENDSTOPS)
   #define MIN_SOFTWARE_ENDSTOP_X
-  //#define MIN_SOFTWARE_ENDSTOP_Y
+  #define MIN_SOFTWARE_ENDSTOP_Y
   //#define MIN_SOFTWARE_ENDSTOP_Z
   #define MIN_SOFTWARE_ENDSTOP_I
   #define MIN_SOFTWARE_ENDSTOP_J


### PR DESCRIPTION

### Description

Limit the Y axis negative movement to -5.0mm. This reduces the amount of crash encountered if you accidentally dial the motion for the Y axis in the negative direction.

### Requirements

CR-30 3DPrintMill

### Benefits

A Better User Experience

### Configurations

Included in the commit.

### Related Issues

No, a request from the Discord firmware channel.