### PR TITLE
Enable HOST_ACTION_COMMANDS

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3784,7 +3784,7 @@
  * Host Prompt Support enables Marlin to use the host for user prompts so
  * filament runout and other processes can be managed from the host side.
  */
-//#define HOST_ACTION_COMMANDS
+#define HOST_ACTION_COMMANDS
 #if ENABLED(HOST_ACTION_COMMANDS)
   //#define HOST_PROMPT_SUPPORT
   //#define HOST_START_MENU_ITEM  // Add a menu item that tells the host to start


### PR DESCRIPTION

### Description

Enable HOST_ACTION_COMMANDS for the CR30

### Requirements

None

### Benefits

This allows Marlin to send host commands to Octoprint

### Configurations

None

### Related Issues

None